### PR TITLE
Stop using person based presence tracking

### DIFF
--- a/home-assistant/martin-pl/integrations/people.yaml
+++ b/home-assistant/martin-pl/integrations/people.yaml
@@ -1,5 +1,5 @@
 group:
   all_people:
     entities:
-      - person.nick_whyte
-      - person.kate_scott
+      - device_tracker.nicks_iphone
+      - device_tracker.kates_iphone


### PR DESCRIPTION
Work around https://github.com/home-assistant/core/issues/63876, changes the `all_people` group to no longer use person based presence for automations. 

Additionally (outside of this PR) migrates the lovelace "people home" card to use `device_tracker` entities instead of `person` entities:

![image](https://user-images.githubusercontent.com/1289759/148901123-e7963687-636d-416d-b5c4-57089dd4130e.png)

![image](https://user-images.githubusercontent.com/1289759/148901217-76f0e5e1-f6d6-4de6-beaf-c7daed41b478.png)

