### PR TITLE
Stop using person based presence tracking

### DIFF
--- a/home-assistant/martin-pl/automations/laundry/notify-on-laundry-door-open.yaml
+++ b/home-assistant/martin-pl/automations/laundry/notify-on-laundry-door-open.yaml
@@ -1,12 +1,12 @@
-id: '1609991469286'
-alias: 'laundry: notify on laundry door open without recent home activity'
-description: ''
+id: "1609991469286"
+alias: "laundry: notify on laundry door open without recent home activity"
+description: ""
 trigger:
-- type: opened
-  platform: device
-  device_id: 6ebac700fde711eabf1a89a94693ffa5
-  entity_id: binary_sensor.laundry_door
-  domain: binary_sensor
+  - type: opened
+    platform: device
+    device_id: 6ebac700fde711eabf1a89a94693ffa5
+    entity_id: binary_sensor.laundry_door
+    domain: binary_sensor
 condition:
   # Alarm is disarmed
   - condition: state
@@ -19,13 +19,13 @@ condition:
   - condition: template
     value_template: >-
       {{ not(
-        (is_state('person.nick', 'home') and (now() - states.person.nick.last_changed).total_seconds() < 600) or
-        (is_state('person.kate', 'home') and (now() - states.person.kate.last_changed).total_seconds() < 600) or
+        (is_state('device_tracker.nicks_iphone', 'home') and (now() - states.device_tracker.nicks_iphone.last_changed).total_seconds() < 600) or
+        (is_state('device_tracker.kates_iphone', 'home') and (now() - states.device_tracker.kates_iphone.last_changed).total_seconds() < 600) or
         (now() - states.binary_sensor.front_door.last_changed).total_seconds() < 300
       ) }}
 action:
-- service: notify.everyone
-  data:
-    title: Laundry Door Opened
-    message: The laundry door was opened at {{ now().strftime('%I:%M %p') }} without recent activity
+  - service: notify.everyone
+    data:
+      title: Laundry Door Opened
+      message: The laundry door was opened at {{ now().strftime('%I:%M %p') }} without recent activity
 mode: single

--- a/home-assistant/martin-pl/automations/presence/clear-away-notifications-when-nick-arrives-home.yaml
+++ b/home-assistant/martin-pl/automations/presence/clear-away-notifications-when-nick-arrives-home.yaml
@@ -2,7 +2,7 @@
 # alias: 'presence: when Nick arrives home, clear door open notifications on Nicks iPhone'
 # description: Disabled since this is not yet possible for iOS companion app
 # trigger:
-#   - entity_id: person.nick_whyte
+#   - entity_id: device_tracker.nicks_iphone
 #     from: not_home
 #     platform: state
 #     to: home

--- a/home-assistant/martin-pl/integrations/people.yaml
+++ b/home-assistant/martin-pl/integrations/people.yaml
@@ -1,5 +1,5 @@
 group:
   all_people:
     entities:
-      - person.nick_whyte
-      - person.kate_scott
+      - device_tracker.nicks_iphone
+      - device_tracker.kates_iphone

--- a/home-assistant/martin-pl/integrations/spotify.yaml
+++ b/home-assistant/martin-pl/integrations/spotify.yaml
@@ -33,11 +33,11 @@ switch:
           - service: spotcast.start
             data:
               entity_id: media_player.soundbar_cast
-              uri: ''
+              uri: ""
               force_playback: true
               shuffle: true
               random_song: true
-              account: "{{ 'nick' if is_state('person.nick_whyte','home') else 'kate' }}"
+              account: "{{ 'nick' if is_state('device_tracker.nicks_iphone','home') else 'kate' }}"
         turn_off:
           - service: media_player.media_pause
             target:


### PR DESCRIPTION
Missed a few usages in #121, re-raising;

Work around https://github.com/home-assistant/core/issues/63876 and https://community.home-assistant.io/t/allow-disabling-of-automatic-gps-device-tracker-being-associated-with-user-upon-login-via-ios-mac-app/378309.

Changes the `all_people` group to no longer use person based presence for automations. 

Additionally (outside of this PR) migrates the lovelace "people home" card to use `device_tracker` entities instead of `person` entities:

![image](https://user-images.githubusercontent.com/1289759/148901123-e7963687-636d-416d-b5c4-57089dd4130e.png)

![image](https://user-images.githubusercontent.com/1289759/148901217-76f0e5e1-f6d6-4de6-beaf-c7daed41b478.png)

