### PR TITLE
Use internal/external urls to fix iOS 15.2 private relay ip ban

### DIFF
--- a/home-assistant/313a/configuration.yaml
+++ b/home-assistant/313a/configuration.yaml
@@ -15,7 +15,7 @@ homeassistant:
         - 192.168.8.0/24
         - 192.168.81.0/24
   packages: !include_dir_named integrations
-  internal_url: !secret http_base_url
+  internal_url: !secret http_base_url_internal
   external_url: !secret http_base_url
   whitelist_external_dirs:
     - /config

--- a/home-assistant/313a/secrets.example.yaml
+++ b/home-assistant/313a/secrets.example.yaml
@@ -3,6 +3,7 @@ latitude: 32.87336
 longitude: 117.22743
 elevation: 400
 http_base_url: 'http://secret'
+http_base_url_internal: 'http://secret'
 
 # integrations/telegram_bot.yaml
 telegram_chat_id: 123456

--- a/home-assistant/martin-pl/configuration.yaml
+++ b/home-assistant/martin-pl/configuration.yaml
@@ -23,7 +23,7 @@ homeassistant:
       allow_bypass_login: true
     - type: homeassistant
   packages: !include_dir_named integrations
-  internal_url: !secret http_base_url
+  internal_url: !secret http_base_url_internal
   external_url: !secret http_base_url
   latitude: !secret latitude
   longitude: !secret longitude

--- a/home-assistant/martin-pl/secrets.example.yaml
+++ b/home-assistant/martin-pl/secrets.example.yaml
@@ -9,6 +9,7 @@ elevation: 400
 # configuration.yaml
 # integrations/http.yaml
 http_base_url: 'http://secret'
+http_base_url_internal: 'http://secret'
 
 # integrations/luci_device_tracker.yaml
 route_password: 'secret'


### PR DESCRIPTION
iOS 15.2 introduced a new "Limit IP Address Tracking", which uses Apple Private relay to try to anonymise IP addresses and limit IP tracking across the internet.

In both of the Home Assistant environments in this repo, we do not use internal/external addresses, instead, a single domain with valid SSL certificate is used. The internal DNS resolver for the network will resolve the domain to the internal IP, and externally, the DNS record for the domain resolves to the external IP of the site where it is hosted.  

This has worked for many years now, and streamlined setup since there was no need to consider whether you were inside the network or outside the network. 

The only time issues occurred was if the internal resolver didn't resolve to the internal IP, but instead the external IP. In these situations, due to NAT hairpin configuration on the router, no external IP information was available, and the requests appeared to come directly from the router IP, and no longer the client IP... 

This meant that all clients appeared to be coming from the same source, which caused Home Assistant's ip_bans module to likely ban the router address and cause denial of service for all users on the local network. Not so good. Fortunately knowing that, it has been less of an issue these days. 

However, it appears the new Apple Private Relay feature messes with routing (as to be expected, it's the premise of the feature) and forces the external IP to be used to resolve the domain, and thus, due to NAT hairpin, causes the router IP to be used to access the Home Assistant instance, again, causing the router IP to be banned and render the Home Assistant instance inaccessible. 

As such, there are two options here:

- Ensure all clients have private relay disabled for the local network (This can be configured on a per-network basis, like private address, so it's a robust solution, but ultimately needs manual configuration on all devices on the network)
- Configure Home Assistant with an internal and external network address. Whilst this means accessing the Home Assistant instance via the browser will likely result in NAT hairpin being used, it means native app clients would hopefully use the right IP depending on their network situation
