### PR TITLE
Add automation to return vacuum when someone approaches home

### DIFF
--- a/home-assistant/martin-pl/automations/vacuum/return-when-approaching-home.yaml
+++ b/home-assistant/martin-pl/automations/vacuum/return-when-approaching-home.yaml
@@ -1,0 +1,20 @@
+id: "1780000000000"
+alias: "robot_vacuum: return when someone is approaching home"
+description: ""
+trigger:
+  - platform: numeric_state
+    entity_id: proximity.home
+    below: 2
+condition:
+  - condition: state
+    entity_id: proximity.home
+    attribute: dir_of_travel
+    state: towards
+  - condition: state
+    entity_id: vacuum.crystal
+    state: cleaning
+action:
+  - service: vacuum.return_to_base
+    target:
+      entity_id: vacuum.crystal
+mode: single


### PR DESCRIPTION
## Summary
- return robot vacuum to dock when a tracked device is moving toward home within 2 km
- use state attribute condition instead of template

## Testing
- `yamllint --version` *(fails: command not found)*
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install PyYAML` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f11474a788331b3ba363ddfe3a3b9