### PR TITLE
Return robot vacuum when someone nears home

### DIFF
--- a/home-assistant/martin-pl/automations/vacuum/start_cleaning_whilst_away.yaml
+++ b/home-assistant/martin-pl/automations/vacuum/start_cleaning_whilst_away.yaml
@@ -112,4 +112,23 @@ action:
         target:
           entity_id: button.x40_ultra_shortcut_6
         data: {}
+  - alias: Wait for cleaning to finish or someone approaches home
+    wait_for_trigger:
+      - platform: state
+        entity_id: vacuum.crystal
+        to: docked
+        id: finished
+      - platform: template
+        value_template: >-
+          {{ state_attr('sensor.home_nearest_distance', 'dir_of_travel') == 'towards' and
+             (states('sensor.home_nearest_distance') | float(99)) < 2 }}
+        id: proximity
+  - choose:
+      - conditions: "{{ wait.trigger.id == 'proximity' }}"
+        sequence:
+          - service: vacuum.return_to_base
+            target:
+              entity_id: vacuum.crystal
+            data: {}
+    default: []
 mode: single


### PR DESCRIPTION
## Summary
- Extend away-cleaning automation to watch for people nearing home
- Recall robot vacuum only when someone is within 2km and moving toward home

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689f1a04b08483319c1dff0238b03320